### PR TITLE
fix(test): stop image-to-text tests leaking a recognize call into later tests

### DIFF
--- a/app/tools/media/image-to-text/__tests__/page.test.tsx
+++ b/app/tools/media/image-to-text/__tests__/page.test.tsx
@@ -837,9 +837,15 @@ describe('ImageToTextPage', () => {
 
   describe('Button Disabled State', () => {
     it('disables upload button during processing', async () => {
-      // Make processing take longer
-      mockCreateWorker.mockImplementation(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 100))
+      // Hold worker creation open with a deferred rather than a real timer. With a
+      // timer the test returned while it was still pending, and when it fired the
+      // component called mockRecognize again - inside a *later* test, which is why
+      // "allows uploading another image after processing" saw 3 calls instead of 2.
+      let startWorker: (() => void) | undefined
+      mockCreateWorker.mockImplementationOnce(async () => {
+        await new Promise<void>((resolve) => {
+          startWorker = resolve
+        })
         return {
           recognize: mockRecognize,
           terminate: mockTerminate,
@@ -851,18 +857,32 @@ describe('ImageToTextPage', () => {
       const file = createMockImageFile()
       uploadFile(file)
 
-      // Find the upload button
-      const uploadButton = screen
-        .getAllByRole('button')
-        .find((btn) => btn.textContent?.includes('Processing'))
+      await waitFor(() => {
+        const uploadButton = screen
+          .getAllByRole('button')
+          .find((btn) => btn.textContent?.includes('Processing'))
+        expect(uploadButton).toBeDisabled()
+      })
 
-      expect(uploadButton).toBeDisabled()
+      const releaseWorker = startWorker
+      if (!releaseWorker) {
+        throw new Error('Expected worker creation to be pending')
+      }
+      releaseWorker()
+
+      // Let processing finish inside the test so nothing is pending on exit.
+      await waitFor(() => {
+        expect(screen.getByText('Extracted text from image')).toBeInTheDocument()
+      })
     })
 
     it('disables language selector during processing', async () => {
-      // Make processing take longer
-      mockCreateWorker.mockImplementation(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 100))
+      // Same deferred hold as above, for the same reason.
+      let startWorker: (() => void) | undefined
+      mockCreateWorker.mockImplementationOnce(async () => {
+        await new Promise<void>((resolve) => {
+          startWorker = resolve
+        })
         return {
           recognize: mockRecognize,
           terminate: mockTerminate,
@@ -875,7 +895,20 @@ describe('ImageToTextPage', () => {
       uploadFile(file)
 
       const select = screen.getByLabelText('Language') as HTMLSelectElement
-      expect(select).toBeDisabled()
+      await waitFor(() => {
+        expect(select).toBeDisabled()
+      })
+
+      const releaseWorker = startWorker
+      if (!releaseWorker) {
+        throw new Error('Expected worker creation to be pending')
+      }
+      releaseWorker()
+
+      // Let processing finish inside the test so nothing is pending on exit.
+      await waitFor(() => {
+        expect(screen.getByText('Extracted text from image')).toBeInTheDocument()
+      })
     })
 
     it('re-enables controls after processing completes', async () => {


### PR DESCRIPTION
## Problem

`Test Coverage` is still failing on `main` after #44, on a **different cause** than the config drift that PR fixed:

```
FAIL app/tools/media/image-to-text/__tests__/page.test.tsx
     > Multiple File Uploads > allows uploading another image after processing
AssertionError: expected "vi.fn()" to be called 2 times, but got 3 times
```

315 files passed, 1 failed. The step ran 362s, so the workflow's 1200s timeout is not involved.

## Root cause

The two `Button Disabled State` tests mocked worker creation with a real `setTimeout(100)`, asserted the disabled control **synchronously**, and returned while the timer was still pending. When it fired, the worker resolved and the component called `recognize` — inside whichever test happened to be running by then. `beforeEach`'s `mockRecognize.mockReset()` does not help, because the stray call lands *after* it.

`allows uploading another image after processing` does exactly two uploads and asserts exactly two calls, so it sees three.

## Proof

Rather than argue from the symptom, I placed a temporary probe test immediately after the first leaky test and ran it under the coverage config:

| | probe result |
| --- | --- |
| old code | `PROBE_LEAK before=0 after=1 leaked=1` |
| this branch | `PROBE_LEAK before=0 after=0 leaked=0` |

The probe was removed before committing.

## Fix

Replace the timer with a controlled deferred that is released and awaited inside the test, so no work outlives it — the same pattern applied to seven other test files in the previous branch.

## Why it only shows up in CI

It needs a slow enough runner. Locally the leaked timer fires while a harmless test is running: **5 consecutive full-file runs on the old code all passed**. That is also why the sharded `CI/CD` run stays green — the leak needs the victim test in the same process — while the single-process coverage run fails.

## Test plan

- `pnpm exec vitest run --config vitest.coverage.config.mts --coverage` — exits 0, **316 files passed, 3 skipped, 54.75% line coverage** (this is the exact command the failing workflow step runs)
- `pnpm lint:check` — clean
- `pnpm exec tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
